### PR TITLE
add support to cargo binaries

### DIFF
--- a/src/modules/rust.eselect
+++ b/src/modules/rust.eselect
@@ -66,7 +66,7 @@ get_last_set_symlinks() {
 }
 
 #get lists of symlinks
-get_symlinks() {
+get_provider_symlinks() {
 	local target=$1
 	if [ "${target}" == "NOT_SET" ]; then
 		echo /usr/bin/rustdoc
@@ -80,6 +80,21 @@ get_symlinks() {
 	local symlinks=( $(get_symlinks_from_file "${EROOT}/etc/env.d/rust/provider-${target}") )
 	echo "${symlinks[@]}"
 }
+
+#get lists of symlinks for cargo binaries
+get_binaries_symlinks() {
+	if is_number "${target}"; then
+		local targets=( $(find_targets) )
+		target=${targets[target]}
+	fi
+
+	local symlinks=()
+	for package in /etc/env.d/rust/*binaries-${target}; do
+		symlinks+=$(get_symlinks_from_file "${EROOT}${package}")
+	done
+	echo "${symlinks[@]}"
+}
+
 
 # remove symlink if exists
 remove_symlink() {
@@ -143,14 +158,21 @@ set_version() {
 
 	set_symlink "${EROOT}/usr/bin/rustc-${target_postfix}" "${EROOT}/usr/bin/rustc"
 
-	local symlinks=( $(get_symlinks ${target}) )
-	for i in "${symlinks[@]}"; do
+	local target_symlinks=( $(get_provider_symlinks ${target}) )
+	for i in "${target_symlinks[@]}"; do
 		set_symlink "${EROOT}${i}-${target_postfix}" "${EROOT}${i}"
 	done
 
 	cp "${EROOT}/etc/env.d/rust/provider-${target}" \
 	   "${EROOT}/etc/env.d/rust/last-set" || \
 	    die -q "symlink list copying failed"
+
+	local binaries_symlinks=( $(get_binaries_symlinks ${target}) )
+	for i in "${binaries_symlinks[@]}"; do
+		set_symlink "${EROOT}/usr/lib/rust-${target_postfix}/bin/$(basename ${i})" "${EROOT}${i}"
+		echo "${i}" >> "${EROOT}/etc/env.d/rust/last-set" || \
+		die -q "binary symlink list copying failed"
+	done
 }
 
 ### list action ###


### PR DESCRIPTION
Eselect looks to ${package}-${rust_target} if a package has been installed
with multiple target from the cargo eclass. This allows binaries that need
to be linked to the proper rustc library to work correctly.

depend on https://github.com/gentoo/gentoo-rust/pull/362